### PR TITLE
API: Add delay_us_2() (delay using hard loop)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+lot-SBC (0.8.1) unstable; urgency=medium
+
+  * API: Add delay_us_2() (delay using hard loop)
+
+ -- Hyeonki Hong <hhk7734@gmail.com>  Sat, 09 Nov 2019 14:25:06 +0000
+
 lot-SBC (0.8.0) unstable; urgency=medium
 
   * API: Add lot_time_init()

--- a/lot_time_linux.cpp
+++ b/lot_time_linux.cpp
@@ -24,7 +24,7 @@
 #include "lot.h"
 
 #include <time.h>
-#include <linux/delay.h>
+#include <sys/time.h>
 
 namespace lot
 {
@@ -43,10 +43,28 @@ void lot_time_init( void )
                    + static_cast<uint64_t>( ts.tv_nsec / 1000L );
 }
 
+static void delay_us_2( uint32_t us )
+{
+    struct timeval t_start;
+    struct timeval t_interval;
+    struct timeval t_end;
+
+    gettimeofday( &t_start, NULL );
+    t_interval.tv_sec  = 0;
+    t_interval.tv_usec = us;
+    timeradd( &t_start, &t_interval, &t_end );
+
+    while( timercmp( &t_start, &t_end, < ) )
+    {
+        gettimeofday( &t_start, NULL );
+    }
+}
+
 void delay_us( uint32_t us )
 {
     if( us > 200 )
     {
+        // The minimum delay made by nanosleep seems to be about 100us.
         struct timespec ts_us;
         struct timespec temp;
 
@@ -57,7 +75,7 @@ void delay_us( uint32_t us )
     }
     else
     {
-        udelay( us );
+        delay_us_2( us );
     }
 }
 


### PR DESCRIPTION
commit e2a024e1f3436b55e465f60fd7a8090afe2ffd81 lot-odroid-n2

linux/delay.h is for kernel, so it failed to call usleep in userspace.